### PR TITLE
chore: add stop hook for doc-editor workflow

### DIFF
--- a/.claude/hooks/doc-editor-continue.sh
+++ b/.claude/hooks/doc-editor-continue.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+
+# Prevent infinite loops — allow stop if already in hook-driven continuation
+if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
+  exit 0
+fi
+
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
+  exit 0
+fi
+
+# Get the last 50 lines of the transcript (enough to cover the current turn)
+TAIL=$(tail -50 "$TRANSCRIPT")
+
+# Check if doc-editor skill was invoked recently
+if echo "$TAIL" | grep -q '"doc-editor"'; then
+  # Check if Edit or Write tool was called after the skill
+  LAST_DOC_EDITOR_LINE=$(echo "$TAIL" | grep -n '"doc-editor"' | tail -1 | cut -d: -f1)
+  REMAINING=$(echo "$TAIL" | tail -n +"$LAST_DOC_EDITOR_LINE")
+
+  if echo "$REMAINING" | grep -qE '"name"\s*:\s*"(Edit|Write)"'; then
+    # Edit/Write found after doc-editor — allow stop
+    exit 0
+  else
+    # doc-editor called but no Edit/Write followed — block stop
+    echo '{"decision":"block","reason":"doc-editor skill was invoked but no Edit or Write followed. Apply the cleaned prose to the file now."}'
+    exit 0
+  fi
+fi
+
+# No doc-editor in recent transcript — allow stop
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /home/ubuntu/github/fastrag/.claude/hooks/doc-editor-continue.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/doc-editor/SKILL.md
+++ b/.claude/skills/doc-editor/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: doc-editor
 description: >
-  You are a technical documentation reviewer. Invoke this skill before writing or editing any
-  markdown file (*.md, README.md, docs/**) — pass the draft text as the argument. You review
-  for two things: (1) technical accuracy — facts, command names, flags, and behaviour must be
-  correct; (2) prose quality — you remove AI-sounding language so the writing reads as if a
-  human wrote it. Return cleaned prose with a brief summary of changes. Skip for code comments,
-  commit messages, and non-prose content (tables, code blocks, CLI output).
+  Reviews draft markdown for accuracy and prose quality, returning cleaned text.
+  This is a preprocessing step — after receiving the result, immediately use the
+  cleaned prose in your pending Edit or Write operation. Do not stop after calling
+  this skill. Skip for code comments, commit messages, and non-prose content.
 argument-hint: "<draft prose to review>"
 allowed-tools: ""
 ---
@@ -59,3 +57,7 @@ Return exactly two sections:
 **Changes** — a short bulleted list: one line per change, stating what was removed or rewritten and which pattern class it fell into.
 
 If the text is already clean, respond: "No changes needed." followed by the original text.
+
+---
+
+**>>> ACTION REQUIRED:** Use the cleaned prose above to complete the pending Edit or Write. Do not stop here.


### PR DESCRIPTION
## Summary
- Adds a Stop hook script that blocks Claude from ending a turn after invoking doc-editor without following up with an Edit or Write
- Updates doc-editor SKILL.md description to emphasize it is a preprocessing step
- Adds ACTION REQUIRED footer to SKILL.md output

## Test plan
- [ ] Verify hook script is executable
- [ ] Confirm settings.json is valid JSON
- [ ] Test doc-editor workflow completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)