### PR TITLE
fix(airgap): cap llama.cpp build parallelism to bound runner RAM

### DIFF
--- a/docker/Dockerfile.airgap
+++ b/docker/Dockerfile.airgap
@@ -55,6 +55,12 @@ RUN cargo build --release -p fastrag-cli \
 # -----------------------------------------------------------------------------
 FROM public.ecr.aws/docker/library/debian:trixie-slim AS llama-builder
 ARG LLAMA_CPP_REF=b8739
+# Cap parallel compile jobs to bound peak RAM during llama.cpp's C++ template
+# instantiation. The default (`-j`) uses every available core; on a 4-vCPU /
+# 16 GB GitHub-hosted runner that produces enough concurrent compiler instances
+# to push the runner OOM and lose communication with the GHA server mid-build
+# (see tarmo/vams#605). Override to a higher value on hosts with more RAM.
+ARG LLAMA_BUILD_JOBS=2
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git cmake build-essential ca-certificates curl libcurl4-openssl-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -69,7 +75,7 @@ RUN git clone --filter=blob:none --branch ${LLAMA_CPP_REF} \
              -DGGML_NATIVE=OFF \
              -DCMAKE_BUILD_TYPE=Release \
              -DLLAMA_BUILD_SERVER=ON \
-    && cmake --build /src/build -j --target llama-server \
+    && cmake --build /src/build -j"${LLAMA_BUILD_JOBS}" --target llama-server \
     && strip /src/build/bin/llama-server
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Cap `cmake --build` parallelism in `docker/Dockerfile.airgap` llama-builder via a new `LLAMA_BUILD_JOBS` ARG (default `2`).
- Prevents OOM on 4-vCPU / 16 GB GitHub-hosted runners that kills the vams `release.yml` offline-bundle build.

## Why

The default `-j` flag uses every available core, so on `ubuntu-latest` (4 vCPU, 16 GB) the llama.cpp C++ template instantiation spawns ~4 concurrent compiler instances. Combined with the docker daemon + buildkit cache + the 2.4 GB Tier 1 GGUF copy elsewhere in the bundle build, the runner runs out of memory and loses communication with the GHA server ~54-56 min in. See tarmo/vams#605 for the failed-run forensics.

Capping at 2 jobs trades a few minutes of build time for headroom. Hosts with more RAM can override:

```bash
docker build --build-arg LLAMA_BUILD_JOBS=8 -f docker/Dockerfile.airgap .
```

## Test plan

- [ ] Re-run `vams release.yml` with `with_offline_bundle=true` and observe the `Build offline analyst bundle` step completes instead of dropping the runner.
- [ ] Local build on a workstation still succeeds (existing path, unchanged behaviour at default).

## Related

- tarmo/vams#605